### PR TITLE
Final config updates for Polygon deployment

### DIFF
--- a/contracts/NftMetadata.sol
+++ b/contracts/NftMetadata.sol
@@ -138,7 +138,7 @@ contract NftMetadata is INftMetadata, Ownable
         "https://arweave.net/bvDHgYSNAB1yQdlajsmbBDKHFW9SEullON3JKzeiyk4",
         "ffffff", "Game");
     setContractMetadata (
-        "https://arweave.net/O3KatG4kpbSTXx5RENrsz83m4x2OYblg2jvqXW_Cu9c");
+        "https://arweave.net/Z-nu82Dj_FsYdcjtkCS1kh8iBDY49oqCAMPaZyXAmEc");
     setDataServerUrl ("https://nft.xaya.io/polygon/");
   }
 

--- a/migrations/1_base.js
+++ b/migrations/1_base.js
@@ -12,7 +12,7 @@ const wchiData = require ("@xaya/wchi/build/contracts/WCHI.json");
 const WCHI = truffleContract (wchiData);
 WCHI.setProvider (XayaAccounts.currentProvider);
 
-const initialFeeInCHI = 10;
+const initialFeeInCHI = 1;
 
 module.exports = async function (deployer, network)
   {


### PR DESCRIPTION
This applies the final configuration parameter updates to the contract before the deployment on Polygon.  In particular, we set the fee per name to a flat 1 WCHI in the policy, and updated the contract metadata link to Arweave.